### PR TITLE
Add base animation class and fade animation

### DIFF
--- a/src/animations/base.py
+++ b/src/animations/base.py
@@ -1,1 +1,31 @@
 """Base animation class."""
+
+from abc import ABC, abstractmethod
+
+from PIL import Image
+
+from src.core.text_renderer import TextRenderer
+
+
+class BaseAnimation(ABC):
+    """Abstract base class for lyric line animations."""
+
+    @abstractmethod
+    def generate_frames(
+        self,
+        text: str,
+        duration: float,
+        fps: int,
+        renderer: TextRenderer,
+    ) -> list[Image.Image]:
+        """Generate the sequence of frames for a single lyric line.
+
+        Args:
+            text: The lyric text to animate.
+            duration: How long this line is displayed, in seconds.
+            fps: Frames per second.
+            renderer: TextRenderer instance for producing styled frames.
+
+        Returns:
+            A list of PIL Images representing each frame.
+        """

--- a/src/animations/fade.py
+++ b/src/animations/fade.py
@@ -1,1 +1,47 @@
 """Fade in/out animation."""
+
+from PIL import Image
+
+from src.animations.base import BaseAnimation
+from src.core.text_renderer import TextRenderer
+
+
+class FadeAnimation(BaseAnimation):
+    """Text fades in, holds, then fades out."""
+
+    def __init__(self, fade_in_duration: float = 0.3, fade_out_duration: float = 0.3):
+        self.fade_in_duration = fade_in_duration
+        self.fade_out_duration = fade_out_duration
+
+    def generate_frames(
+        self,
+        text: str,
+        duration: float,
+        fps: int,
+        renderer: TextRenderer,
+    ) -> list[Image.Image]:
+        total_frames = max(1, int(duration * fps))
+        fade_in_frames = int(self.fade_in_duration * fps)
+        fade_out_frames = int(self.fade_out_duration * fps)
+
+        # Ensure fade frames don't exceed total
+        if fade_in_frames + fade_out_frames > total_frames:
+            fade_in_frames = total_frames // 3
+            fade_out_frames = total_frames // 3
+
+        frames = []
+        for i in range(total_frames):
+            if i < fade_in_frames:
+                # Fade in: 0.0 -> 1.0
+                alpha = i / fade_in_frames
+            elif i >= total_frames - fade_out_frames:
+                # Fade out: 1.0 -> 0.0
+                remaining = total_frames - 1 - i
+                alpha = remaining / fade_out_frames
+            else:
+                # Hold at full opacity
+                alpha = 1.0
+
+            frames.append(renderer.render_frame(text, alpha=alpha))
+
+        return frames


### PR DESCRIPTION
## Summary
- Added `src/animations/base.py` — `BaseAnimation` ABC with abstract `generate_frames(text, duration, fps, renderer)` method
- Added `src/animations/fade.py` — `FadeAnimation` that fades text in (~0.3s), holds, then fades out (~0.3s)
  - Configurable `fade_in_duration` and `fade_out_duration`
  - Gracefully scales fade times down when the lyric line is very short

Closes #4

## Test plan
- [ ] Instantiate FadeAnimation and generate frames for a 3s line at 30fps — expect 90 frames
- [ ] Verify first ~9 frames have increasing alpha (fade in) and last ~9 have decreasing alpha (fade out)
- [ ] Test with a very short duration (0.5s) to confirm fade times scale down without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)