### PR TITLE
Add slide-up and typewriter animations

### DIFF
--- a/src/animations/slide.py
+++ b/src/animations/slide.py
@@ -1,1 +1,51 @@
 """Slide up/down animation."""
+
+from PIL import Image
+
+from src.animations.base import BaseAnimation
+from src.core.text_renderer import TextRenderer, HEIGHT
+
+
+class SlideAnimation(BaseAnimation):
+    """Text slides up from below into center, holds, then slides out upward."""
+
+    def __init__(self, slide_in_duration: float = 0.3, slide_out_duration: float = 0.3):
+        self.slide_in_duration = slide_in_duration
+        self.slide_out_duration = slide_out_duration
+
+    def generate_frames(
+        self,
+        text: str,
+        duration: float,
+        fps: int,
+        renderer: TextRenderer,
+    ) -> list[Image.Image]:
+        total_frames = max(1, int(duration * fps))
+        slide_in_frames = int(self.slide_in_duration * fps)
+        slide_out_frames = int(self.slide_out_duration * fps)
+
+        # Ensure slide frames don't exceed total
+        if slide_in_frames + slide_out_frames > total_frames:
+            slide_in_frames = total_frames // 3
+            slide_out_frames = total_frames // 3
+
+        # Distance to travel: from just below screen to center (0 offset)
+        travel = HEIGHT // 2
+
+        frames = []
+        for i in range(total_frames):
+            if i < slide_in_frames:
+                # Slide in from below: large positive y_offset -> 0
+                progress = i / slide_in_frames
+                y_offset = int(travel * (1.0 - progress))
+            elif i >= total_frames - slide_out_frames:
+                # Slide out upward: 0 -> large negative y_offset
+                progress = (i - (total_frames - slide_out_frames)) / slide_out_frames
+                y_offset = int(-travel * progress)
+            else:
+                # Hold at center
+                y_offset = 0
+
+            frames.append(renderer.render_frame(text, y_offset=y_offset))
+
+        return frames

--- a/src/animations/typewriter.py
+++ b/src/animations/typewriter.py
@@ -1,1 +1,35 @@
 """Typewriter effect animation."""
+
+from PIL import Image
+
+from src.animations.base import BaseAnimation
+from src.core.text_renderer import TextRenderer
+
+
+class TypewriterAnimation(BaseAnimation):
+    """Characters appear one at a time, evenly spaced across the line's duration."""
+
+    def generate_frames(
+        self,
+        text: str,
+        duration: float,
+        fps: int,
+        renderer: TextRenderer,
+    ) -> list[Image.Image]:
+        total_frames = max(1, int(duration * fps))
+        char_count = len(text)
+
+        if char_count == 0:
+            return [renderer.render_frame("") for _ in range(total_frames)]
+
+        frames = []
+        for i in range(total_frames):
+            # How many characters should be visible at this frame
+            progress = (i + 1) / total_frames
+            visible_chars = int(progress * char_count)
+            visible_chars = min(visible_chars, char_count)
+
+            partial_text = text[:visible_chars]
+            frames.append(renderer.render_frame(partial_text))
+
+        return frames

--- a/src/core/text_renderer.py
+++ b/src/core/text_renderer.py
@@ -31,12 +31,13 @@ class TextRenderer:
                     continue
             return ImageFont.load_default()
 
-    def render_frame(self, text: str, alpha: float = 1.0) -> Image.Image:
+    def render_frame(self, text: str, alpha: float = 1.0, y_offset: int = 0) -> Image.Image:
         """Render a single frame with the given text.
 
         Args:
             text: The lyric text to render.
             alpha: Opacity of the text (0.0 to 1.0), used by animations.
+            y_offset: Vertical pixel offset from the base position (for slide animations).
 
         Returns:
             A 1920x1080 RGBA PIL Image.
@@ -61,6 +62,7 @@ class TextRenderer:
 
         # Position
         x, y = self._compute_position(text_w, text_h)
+        y += y_offset
 
         # Convert alpha to 0-255
         a = int(alpha * 255)


### PR DESCRIPTION
## Summary
- Added `src/animations/slide.py` — `SlideAnimation` that slides text up from below into center (~0.3s), holds, then slides out upward (~0.3s)
- Added `src/animations/typewriter.py` — `TypewriterAnimation` that reveals characters one at a time, evenly spaced across the line duration
- Updated `src/core/text_renderer.py` — added `y_offset` parameter to `render_frame()` to support positional animations

Closes #5

## Test plan
- [ ] SlideAnimation: generate frames for a 3s line at 30fps, verify y_offset transitions from positive → 0 → negative
- [ ] TypewriterAnimation: generate frames for "Hello" at 30fps over 1s, verify characters appear progressively
- [ ] TypewriterAnimation: test with empty text — should produce blank frames without errors
- [ ] Verify existing FadeAnimation still works (render_frame signature is backwards-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)