### PR TITLE
Fix moviepy v2 compatibility and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ Generate lyric videos with timed text animations from a JSON lyrics file and an 
 git clone https://github.com/CuWilliams/lyric-video-generator.git
 cd lyric-video-generator
 
-# Install dependencies
-pip install -r requirements.txt
+# Create and activate a virtual environment
+python3 -m venv venv
+source venv/bin/activate   # On Windows: venv\Scripts\activate
 
-# Or install as a package (makes the lyric-video command available)
+# Install as an editable package (installs deps + registers the lyric-video command)
 pip install -e .
 ```
+
+> **Note:** On macOS, use `pip3` instead of `pip` if you are not in a virtual environment.
 
 ### FFmpeg
 
@@ -54,7 +57,7 @@ lyric-video --lyrics examples/sample_lyrics.json \
 ### Examples
 
 ```bash
-# Quick preview with default settings
+# Quick preview with default settings (first 30 seconds)
 lyric-video --lyrics examples/sample_lyrics.json --audio song.mp3 --preview
 
 # Full video with slide animation
@@ -63,13 +66,23 @@ lyric-video --lyrics examples/sample_lyrics.json --audio song.mp3 --animation sl
 # Custom output path and theme
 lyric-video --lyrics my_lyrics.json --audio my_song.wav \
             --theme my_theme.json --output my_video.mp4
+
+# Audio path with spaces (use quotes)
+lyric-video --lyrics examples/sample_lyrics.json \
+            --audio "/path/to/My Song.mp3"
 ```
 
-You can also run the CLI directly without installing:
+You can also run the CLI directly without installing the package:
 
 ```bash
 python -m src.cli.main --lyrics examples/sample_lyrics.json --audio song.mp3
 ```
+
+### Notes
+
+- The `--preview` flag is useful for quickly testing your lyrics/theme before generating a full-length video.
+- Generated videos are saved to the `output/` directory by default. This directory is gitignored.
+- If lyrics start after 0:00 (e.g. an instrumental intro), the video will show a blank background until the first lyric line.
 
 ## Lyrics Format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "lyric-video-generator"
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Generate lyric videos with timed text animations"
 requires-python = ">=3.10"
 dependencies = [
-    "moviepy>=1.0.3",
+    "moviepy>=2.0.0",
     "Pillow>=10.0.0",
     "click>=8.0.0",
     "numpy>=1.24.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-moviepy>=1.0.3
+moviepy>=2.0.0
 Pillow>=10.0.0
 click>=8.0.0
 numpy>=1.24.0

--- a/src/core/audio_handler.py
+++ b/src/core/audio_handler.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from moviepy.editor import AudioFileClip
+from moviepy import AudioFileClip
 
 
 def load_audio(filepath: str | Path) -> AudioFileClip:


### PR DESCRIPTION
## Summary
- Fixed build backend (`setuptools.backends._legacy` -> `setuptools.build_meta`) that caused `pip install -e .` to fail
- Updated all moviepy imports from `moviepy.editor` to `moviepy` (v2 removed the `.editor` submodule)
- Updated moviepy API calls: `set_fps` -> `with_fps`, `set_audio` -> `with_audio`, `subclip` -> `subclipped`, positional arg -> `frame_function` kwarg
- Pre-convert PIL frames to `np.uint8` arrays during setup for reliable video encoding
- Pinned `moviepy>=2.0.0` in both `requirements.txt` and `pyproject.toml`
- Updated README with venv setup, `pip3` note for macOS, quoted paths example, and usage notes

## Test plan
- [x] `pip install -e .` succeeds
- [x] `lyric-video --preview` generates video with text and audio
- [x] ffprobe confirms H.264 video + AAC audio streams in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)